### PR TITLE
Make num_samples behave same for torch setup

### DIFF
--- a/path_explain/explainers/path_explainer_torch.py
+++ b/path_explain/explainers/path_explainer_torch.py
@@ -99,8 +99,8 @@ class PathExplainerTorch(object):
             reps[0] = batch_size
             reference_tensor = baseline.repeat(list(reps)).unsqueeze(1)
 #             reference_tensor = torch.as_tensor(sampled_baseline).unsqueeze(1).to(baseline.device)
-            scaled_inputs = [reference_tensor + (float(i)/num_samples)*(input_expand - reference_tensor) \
-                             for i in range(0,num_samples+1)]
+            scaled_inputs = [reference_tensor + (float(i)/(num_samples-1))*(input_expand - reference_tensor) \
+                             for i in range(0,num_samples)]
             samples_input = torch.cat(scaled_inputs,dim=1)
         
         samples_delta = self._get_samples_delta(input_tensor, reference_tensor)


### PR DESCRIPTION
As discussed in issue #8, the torch setup with `use_expectations=False` now behaves the same as for Tensorflow models. 

Btw, I had to add `num_samples-1` in the fraction as well, because the `range(0, num_samples)` now ranges from 0 to `num_samples-1`. I checked the output of the two model types and the output is now the same.